### PR TITLE
spdm: add digests

### DIFF
--- a/examples/spdm_requester.rs
+++ b/examples/spdm_requester.rs
@@ -28,6 +28,7 @@ use spdm_lib::commands::algorithms::{
     request::generate_negotiate_algorithms_request, AlgStructure, AlgType, ExtendedAlgo, RegistryId,
 };
 use spdm_lib::commands::capabilities::request::generate_capabilities_request_local;
+use spdm_lib::commands::digests::request::generate_digest_request;
 use spdm_lib::commands::version::{request::generate_get_version, VersionReqPayload};
 
 /// Responder configuration
@@ -118,7 +119,7 @@ fn create_local_algorithms<'a>() -> LocalDeviceAlgorithms<'a> {
 
 // Perform a VCS flow (Version, Capabilities, Algorithms)
 // using the real SPDM library processing with platform implementations.
-fn vca_flow(stream: TcpStream, config: &RequesterConfig) -> IoResult<()> {
+fn full_flow(stream: TcpStream, config: &RequesterConfig) -> IoResult<()> {
     let mut transport = SpdmSocketTransport::new(
         stream,
         platform::socket_transport::SocketTransportType::None,
@@ -306,6 +307,26 @@ fn vca_flow(stream: TcpStream, config: &RequesterConfig) -> IoResult<()> {
         println!("ALGORITHMS: {:x?}", &message_buffer.message_data());
     }
 
+    println!("SPDM VCA flow completed successfully");
+
+    message_buffer.reset();
+    generate_digest_request(&mut spdm_context, &mut message_buffer).unwrap();
+    spdm_context
+        .requester_send_request(&mut message_buffer, EID)
+        .unwrap();
+
+    if config.verbose {
+        println!("GET_DIGESTS: {:x?}", &message_buffer.message_data());
+    }
+
+    spdm_context
+        .requester_process_message(&mut message_buffer)
+        .unwrap();
+
+    if config.verbose {
+        println!("DIGESTS: {:x?}", &message_buffer.message_data());
+    }
+
     Ok(())
 }
 
@@ -470,7 +491,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     // Handle client with real SPDM processing using platform implementations
-    vca_flow(stream, &config)?;
+    full_flow(stream, &config)?;
 
     Ok(())
 }

--- a/src/commands/challenge_auth_rsp.rs
+++ b/src/commands/challenge_auth_rsp.rs
@@ -2,7 +2,7 @@
 use crate::cert_store::MAX_CERT_SLOTS_SUPPORTED;
 use crate::codec::{Codec, CommonCodec, MessageBuf};
 use crate::commands::algorithms::selected_measurement_specification;
-use crate::commands::digests_rsp::compute_cert_chain_hash;
+use crate::commands::digests::compute_cert_chain_hash;
 use crate::commands::error_rsp::ErrorCode;
 use crate::context::SpdmContext;
 use crate::error::{CommandError, CommandResult, PlatformError};

--- a/src/commands/digests/mod.rs
+++ b/src/commands/digests/mod.rs
@@ -2,15 +2,19 @@
 
 use crate::cert_store::{cert_slot_mask, SpdmCertStore};
 use crate::codec::{Codec, CommonCodec, MessageBuf};
-use crate::commands::error_rsp::ErrorCode;
 use crate::context::SpdmContext;
 use crate::error::{CommandError, CommandResult, PlatformError};
 use crate::platform::hash::{SpdmHash, SpdmHashAlgoType};
+
 use crate::protocol::*;
-use crate::state::ConnectionState;
-use crate::transcript::TranscriptContext;
-use core::mem::size_of;
+
 use zerocopy::{FromBytes, Immutable, IntoBytes};
+
+pub mod request;
+pub mod response;
+
+pub(crate) use request::*;
+pub(crate) use response::*;
 
 #[derive(IntoBytes, FromBytes, Immutable, Default)]
 #[repr(C)]
@@ -121,69 +125,6 @@ fn encode_cert_chain_digest(
     Ok(SHA384_HASH_SIZE)
 }
 
-fn generate_digests_response<'a>(
-    ctx: &mut SpdmContext<'a>,
-    rsp: &mut MessageBuf<'a>,
-) -> CommandResult<()> {
-    // Ensure the selected hash algorithm is SHA384 and retrieve the asymmetric algorithm (currently only ECC-P384 is supported)
-    ctx.verify_selected_hash_algo()
-        .map_err(|_| ctx.generate_error_response(rsp, ErrorCode::Unspecified, 0, None))?;
-    let asym_algo = ctx
-        .selected_base_asym_algo()
-        .map_err(|_| ctx.generate_error_response(rsp, ErrorCode::Unspecified, 0, None))?;
-
-    // Get the supported and provisioned slot masks.
-    let (supported_slot_mask, provisioned_slot_mask) = cert_slot_mask(ctx.device_certs_store);
-
-    // No slots provisioned with certificates
-    let slot_cnt = provisioned_slot_mask.count_ones() as usize;
-    if slot_cnt == 0 {
-        Err(ctx.generate_error_response(rsp, ErrorCode::Unspecified, 0, None))?;
-    }
-
-    let connection_version = ctx.state.connection_info.version_number();
-
-    // Start filling the response payload
-    let spdm_resp_hdr = SpdmMsgHdr::new(connection_version, ReqRespCode::Digests);
-    let mut payload_len = spdm_resp_hdr
-        .encode(rsp)
-        .map_err(|_| (false, CommandError::BufferTooSmall))?;
-
-    // Fill the response header with param1 and param2
-    let dgst_rsp_common = GetDigestsRespCommon {
-        supported_slot_mask,
-        provisioned_slot_mask,
-    };
-
-    payload_len += dgst_rsp_common
-        .encode(rsp)
-        .map_err(|_| (false, CommandError::BufferTooSmall))?;
-
-    // Encode the certificate chain digests for each provisioned slot
-    for slot_id in 0..slot_cnt {
-        payload_len += encode_cert_chain_digest(
-            ctx.hash,
-            slot_id as u8,
-            ctx.device_certs_store,
-            asym_algo,
-            rsp,
-        )
-        .map_err(|_| ctx.generate_error_response(rsp, ErrorCode::Unspecified, 0, None))?;
-    }
-
-    // Fill the multi-key connection response data if applicable
-    if connection_version >= SpdmVersion::V13 && ctx.state.connection_info.multi_key_conn_rsp() {
-        payload_len += encode_multi_key_conn_rsp_data(ctx, provisioned_slot_mask, rsp)?;
-    }
-
-    // Push data offset up by total payload length
-    rsp.push_data(payload_len)
-        .map_err(|_| (false, CommandError::BufferTooSmall))?;
-
-    // Append the response message to the M1 transcript
-    ctx.append_message_to_transcript(rsp, TranscriptContext::M1)
-}
-
 fn encode_multi_key_conn_rsp_data(
     ctx: &mut SpdmContext,
     provisioned_slot_mask: u8,
@@ -243,63 +184,4 @@ fn encode_multi_key_conn_rsp_data(
         .map_err(|_| (false, CommandError::BufferTooSmall))?;
 
     Ok(total_size)
-}
-
-fn process_get_digests<'a>(
-    ctx: &mut SpdmContext<'a>,
-    spdm_hdr: SpdmMsgHdr,
-    req_payload: &mut MessageBuf<'a>,
-) -> CommandResult<()> {
-    // Validate the version
-    let connection_version = ctx.state.connection_info.version_number();
-    match spdm_hdr.version() {
-        Ok(version) if version == connection_version => {}
-        _ => Err(ctx.generate_error_response(req_payload, ErrorCode::VersionMismatch, 0, None))?,
-    }
-
-    let req = GetDigestsReq::decode(req_payload).map_err(|_| {
-        ctx.generate_error_response(req_payload, ErrorCode::InvalidRequest, 0, None)
-    })?;
-
-    // Reserved fields must be zero - or unexpected request error
-    if req.param1 != 0 || req.param2 != 0 {
-        Err(ctx.generate_error_response(req_payload, ErrorCode::UnexpectedRequest, 0, None))?;
-    }
-
-    // Reset the transcript manager
-    ctx.reset_transcript_via_req_code(ReqRespCode::GetDigests);
-
-    // Append the request message to the M1 transcript
-    ctx.append_message_to_transcript(req_payload, TranscriptContext::M1)
-}
-
-pub(crate) fn handle_get_digests<'a>(
-    ctx: &mut SpdmContext<'a>,
-    spdm_hdr: SpdmMsgHdr,
-    req_payload: &mut MessageBuf<'a>,
-) -> CommandResult<()> {
-    // Validate the connection state
-    if ctx.state.connection_info.state() < ConnectionState::AlgorithmsNegotiated {
-        Err(ctx.generate_error_response(req_payload, ErrorCode::UnexpectedRequest, 0, None))?;
-    }
-
-    // Check if the certificate capability is supported
-    if ctx.local_capabilities.flags.cert_cap() == 0 {
-        Err(ctx.generate_error_response(req_payload, ErrorCode::UnsupportedRequest, 0, None))?;
-    }
-
-    // Process GET_DIGESTS request
-    process_get_digests(ctx, spdm_hdr, req_payload)?;
-
-    // Generate DIGESTS response
-    ctx.prepare_response_buffer(req_payload)?;
-    generate_digests_response(ctx, req_payload)?;
-
-    if ctx.state.connection_info.state() < ConnectionState::AfterDigest {
-        ctx.state
-            .connection_info
-            .set_state(ConnectionState::AfterDigest);
-    }
-
-    Ok(())
 }

--- a/src/commands/digests/request.rs
+++ b/src/commands/digests/request.rs
@@ -1,0 +1,145 @@
+// Licensed under the Apache-2.0 license
+
+use crate::codec::Codec;
+use crate::context::SpdmContext;
+use crate::error::{CommandError, CommandResult};
+use crate::protocol::certs::{CertificateInfo, KeyUsageMask};
+use crate::protocol::{SpdmMsgHdr, SpdmVersion, SHA384_HASH_SIZE};
+use crate::state::ConnectionState;
+use crate::transcript::TranscriptContext;
+use zerocopy::FromBytes;
+
+use super::*;
+
+pub fn generate_digest_request(
+    ctx: &mut SpdmContext,
+    message_buffer: &mut MessageBuf,
+) -> CommandResult<()> {
+    SpdmMsgHdr::new(
+        ctx.state.connection_info.version_number(),
+        crate::protocol::ReqRespCode::GetDigests,
+    )
+    .encode(message_buffer)
+    .map_err(|e| (false, CommandError::Codec(e)))?;
+
+    let payload = GetDigestsReq::default();
+    payload
+        .encode(message_buffer)
+        .map_err(|e| (false, CommandError::Codec(e)))?;
+
+    ctx.append_message_to_transcript(message_buffer, crate::transcript::TranscriptContext::L1)
+}
+
+pub(crate) fn handle_digests_response<'a>(
+    ctx: &mut SpdmContext<'a>,
+    spdm_hdr: SpdmMsgHdr,
+    resp_payload: &mut MessageBuf<'a>,
+) -> CommandResult<()> {
+    if ctx.state.connection_info.state() < ConnectionState::AlgorithmsNegotiated {
+        return Err((false, CommandError::UnsupportedRequest));
+    }
+
+    let con_version = ctx.state.connection_info.version_number();
+    let version = match spdm_hdr.version() {
+        Ok(version) if version == con_version => version,
+        _ => return Err((false, CommandError::InvalidResponse)),
+    };
+
+    let digests_resp_common =
+        GetDigestsRespCommon::decode(resp_payload).map_err(|e| (false, CommandError::Codec(e)))?;
+
+    // ATM we do not care, since we only support slot 0.
+    // Also this is a hacky way of representing the the remote slots
+    let _supported_slot_mask = digests_resp_common.supported_slot_mask;
+    let provisioned_slot_mask = digests_resp_common.provisioned_slot_mask;
+
+    let slot_n = provisioned_slot_mask.count_ones() as usize;
+    if slot_n == 0 {
+        return Err((false, CommandError::InvalidResponse));
+    }
+
+    for _slot_id in 0..slot_n {
+        if resp_payload.data_len() < SHA384_HASH_SIZE {
+            return Err((false, CommandError::InvalidResponse));
+        }
+
+        let _digest = resp_payload
+            .data(SHA384_HASH_SIZE)
+            .map_err(|e| (false, CommandError::Codec(e)))?;
+
+        // TODO: Store the digest in context for later verification
+
+        resp_payload
+            .pull_data(SHA384_HASH_SIZE)
+            .map_err(|e| (false, CommandError::Codec(e)))?;
+    }
+
+    if version >= SpdmVersion::V13 && ctx.state.connection_info.multi_key_conn_rsp() {
+        for _slot_id in 0..slot_n {
+            if resp_payload.data_len() < size_of::<u8>() {
+                return Err((false, CommandError::InvalidResponse));
+            }
+            let _key_pair_id = resp_payload
+                .data(size_of::<u8>())
+                .map_err(|e| (false, CommandError::Codec(e)))?[0];
+
+            // TODO: Store key_pair_id in context
+
+            resp_payload
+                .pull_data(size_of::<u8>())
+                .map_err(|e| (false, CommandError::Codec(e)))?;
+        }
+
+        for _slot_id in 0..slot_n {
+            if resp_payload.data_len() < size_of::<CertificateInfo>() {
+                return Err((false, CommandError::InvalidResponse));
+            }
+            let data = resp_payload
+                .data(size_of::<CertificateInfo>())
+                .map_err(|e| (false, CommandError::Codec(e)))?;
+            let _cert_info = CertificateInfo::read_from_bytes(data)
+                .map_err(|_| (false, CommandError::InvalidResponse))?;
+
+            // TODO: Store cert_info in context
+
+            resp_payload
+                .pull_data(size_of::<CertificateInfo>())
+                .map_err(|e| (false, CommandError::Codec(e)))?;
+        }
+
+        // Decode KeyUsageMasks (one per slot)
+        for _slot_id in 0..slot_n {
+            if resp_payload.data_len() < size_of::<KeyUsageMask>() {
+                return Err((false, CommandError::InvalidResponse));
+            }
+            let data = resp_payload
+                .data(size_of::<KeyUsageMask>())
+                .map_err(|e| (false, CommandError::Codec(e)))?;
+            let _key_usage_mask = KeyUsageMask::read_from_bytes(data)
+                .map_err(|_| (false, CommandError::InvalidResponse))?;
+
+            // TODO: Store key_usage_mask in context
+
+            resp_payload
+                .pull_data(size_of::<KeyUsageMask>())
+                .map_err(|e| (false, CommandError::Codec(e)))?;
+        }
+    }
+
+    if ctx.state.connection_info.state() < ConnectionState::AfterDigest {
+        ctx.state
+            .connection_info
+            .set_state(ConnectionState::AfterDigest);
+    }
+
+    ctx.append_message_to_transcript(resp_payload, TranscriptContext::L1)
+}
+
+#[cfg(test)]
+pub mod tests {
+
+    #[test]
+    fn test_generate_digest_request() {
+        todo!();
+    }
+}

--- a/src/commands/digests/response.rs
+++ b/src/commands/digests/response.rs
@@ -1,0 +1,135 @@
+// Licensed under the Apache-2.0 license
+
+use crate::cert_store::{cert_slot_mask, SpdmCertStore};
+use crate::codec::{Codec, CommonCodec, MessageBuf};
+use crate::commands::error_rsp::ErrorCode;
+use crate::context::SpdmContext;
+use crate::error::{CommandError, CommandResult, PlatformError};
+use crate::platform::hash::{SpdmHash, SpdmHashAlgoType};
+use crate::state::ConnectionState;
+use crate::transcript::TranscriptContext;
+use zerocopy::{FromBytes, Immutable, IntoBytes};
+
+use super::*;
+
+pub(crate) fn generate_digests_response<'a>(
+    ctx: &mut SpdmContext<'a>,
+    rsp: &mut MessageBuf<'a>,
+) -> CommandResult<()> {
+    // Ensure the selected hash algorithm is SHA384 and retrieve the asymmetric algorithm (currently only ECC-P384 is supported)
+    ctx.verify_selected_hash_algo()
+        .map_err(|_| ctx.generate_error_response(rsp, ErrorCode::Unspecified, 0, None))?;
+    let asym_algo = ctx
+        .selected_base_asym_algo()
+        .map_err(|_| ctx.generate_error_response(rsp, ErrorCode::Unspecified, 0, None))?;
+
+    // Get the supported and provisioned slot masks.
+    let (supported_slot_mask, provisioned_slot_mask) = cert_slot_mask(ctx.device_certs_store);
+
+    // No slots provisioned with certificates
+    let slot_cnt = provisioned_slot_mask.count_ones() as usize;
+    if slot_cnt == 0 {
+        Err(ctx.generate_error_response(rsp, ErrorCode::Unspecified, 0, None))?;
+    }
+
+    let connection_version = ctx.state.connection_info.version_number();
+
+    // Start filling the response payload
+    let spdm_resp_hdr = SpdmMsgHdr::new(connection_version, ReqRespCode::Digests);
+    let mut payload_len = spdm_resp_hdr
+        .encode(rsp)
+        .map_err(|_| (false, CommandError::BufferTooSmall))?;
+
+    // Fill the response header with param1 and param2
+    let dgst_rsp_common = GetDigestsRespCommon {
+        supported_slot_mask,
+        provisioned_slot_mask,
+    };
+
+    payload_len += dgst_rsp_common
+        .encode(rsp)
+        .map_err(|_| (false, CommandError::BufferTooSmall))?;
+
+    // Encode the certificate chain digests for each provisioned slot
+    for slot_id in 0..slot_cnt {
+        payload_len += encode_cert_chain_digest(
+            ctx.hash,
+            slot_id as u8,
+            ctx.device_certs_store,
+            asym_algo,
+            rsp,
+        )
+        .map_err(|_| ctx.generate_error_response(rsp, ErrorCode::Unspecified, 0, None))?;
+    }
+
+    // Fill the multi-key connection response data if applicable
+    if connection_version >= SpdmVersion::V13 && ctx.state.connection_info.multi_key_conn_rsp() {
+        payload_len += encode_multi_key_conn_rsp_data(ctx, provisioned_slot_mask, rsp)?;
+    }
+
+    // Push data offset up by total payload length
+    rsp.push_data(payload_len)
+        .map_err(|_| (false, CommandError::BufferTooSmall))?;
+
+    // Append the response message to the M1 transcript
+    ctx.append_message_to_transcript(rsp, TranscriptContext::M1)
+}
+
+fn process_get_digests<'a>(
+    ctx: &mut SpdmContext<'a>,
+    spdm_hdr: SpdmMsgHdr,
+    req_payload: &mut MessageBuf<'a>,
+) -> CommandResult<()> {
+    // Validate the version
+    let connection_version = ctx.state.connection_info.version_number();
+    match spdm_hdr.version() {
+        Ok(version) if version == connection_version => {}
+        _ => Err(ctx.generate_error_response(req_payload, ErrorCode::VersionMismatch, 0, None))?,
+    }
+
+    let req = GetDigestsReq::decode(req_payload).map_err(|_| {
+        ctx.generate_error_response(req_payload, ErrorCode::InvalidRequest, 0, None)
+    })?;
+
+    // Reserved fields must be zero - or unexpected request error
+    if req.param1 != 0 || req.param2 != 0 {
+        Err(ctx.generate_error_response(req_payload, ErrorCode::UnexpectedRequest, 0, None))?;
+    }
+
+    // Reset the transcript manager
+    ctx.reset_transcript_via_req_code(ReqRespCode::GetDigests);
+
+    // Append the request message to the M1 transcript
+    ctx.append_message_to_transcript(req_payload, TranscriptContext::M1)
+}
+
+pub(crate) fn handle_get_digests<'a>(
+    ctx: &mut SpdmContext<'a>,
+    spdm_hdr: SpdmMsgHdr,
+    req_payload: &mut MessageBuf<'a>,
+) -> CommandResult<()> {
+    // Validate the connection state
+    if ctx.state.connection_info.state() < ConnectionState::AlgorithmsNegotiated {
+        Err(ctx.generate_error_response(req_payload, ErrorCode::UnexpectedRequest, 0, None))?;
+    }
+
+    // Check if the certificate capability is supported
+    if ctx.local_capabilities.flags.cert_cap() == 0 {
+        Err(ctx.generate_error_response(req_payload, ErrorCode::UnsupportedRequest, 0, None))?;
+    }
+
+    // Process GET_DIGESTS request
+    process_get_digests(ctx, spdm_hdr, req_payload)?;
+
+    // Generate DIGESTS response
+    ctx.prepare_response_buffer(req_payload)?;
+    generate_digests_response(ctx, req_payload)?;
+
+    if ctx.state.connection_info.state() < ConnectionState::AfterDigest {
+        ctx.state
+            .connection_info
+            .set_state(ConnectionState::AfterDigest);
+    }
+
+    Ok(())
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -5,7 +5,7 @@ pub mod capabilities;
 pub mod certificate_rsp;
 pub mod challenge_auth_rsp;
 pub mod chunk_get_rsp;
-pub mod digests_rsp;
+pub mod digests;
 pub mod error_rsp;
 pub mod measurements_rsp;
 pub mod version;

--- a/src/context.rs
+++ b/src/context.rs
@@ -5,12 +5,14 @@ use crate::cert_store::*;
 use crate::chunk_ctx::LargeResponseCtx;
 use crate::codec::{Codec, MessageBuf};
 use crate::commands::capabilities::handle_capabilities_response;
+use crate::commands::digests::{handle_digests_response, handle_get_digests};
 use crate::commands::error_rsp::{encode_error_response, ErrorCode};
 use crate::commands::version::handle_version_response;
 use crate::commands::{
-    algorithms, capabilities, certificate_rsp, challenge_auth_rsp, chunk_get_rsp, digests_rsp,
-    measurements_rsp, version,
+    algorithms, capabilities, certificate_rsp, challenge_auth_rsp, chunk_get_rsp, measurements_rsp,
+    version,
 };
+
 use crate::error::*;
 use crate::measurements::common::SpdmMeasurements;
 use crate::platform::evidence::SpdmEvidence;
@@ -169,7 +171,7 @@ impl<'a> SpdmContext<'a> {
             ReqRespCode::NegotiateAlgorithms => {
                 algorithms::handle_negotiate_algorithms(self, req_msg_header, req)?
             }
-            ReqRespCode::GetDigests => digests_rsp::handle_get_digests(self, req_msg_header, req)?,
+            ReqRespCode::GetDigests => handle_get_digests(self, req_msg_header, req)?,
             ReqRespCode::GetCertificate => {
                 certificate_rsp::handle_get_certificate(self, req_msg_header, req)?
             }
@@ -214,6 +216,7 @@ impl<'a> SpdmContext<'a> {
             ReqRespCode::Algorithms => {
                 algorithms::handle_algorithms_response(self, resp_msg_header, resp)?
             }
+            ReqRespCode::Digests => handle_digests_response(self, resp_msg_header, resp)?,
             _ => Err((false, CommandError::UnsupportedResponse))?,
         }
 

--- a/src/measurements/freeform_manifest.rs
+++ b/src/measurements/freeform_manifest.rs
@@ -150,7 +150,7 @@ impl FreeformManifest {
 
         let copied_len = evidence
             .pcr_quote(quote_slice, with_pqc_sig)
-            .map_err(|e| MeasurementsError::Evidence(e))?;
+            .map_err(MeasurementsError::Evidence)?;
         if copied_len != measurement_value_size {
             return Err(MeasurementsError::MeasurementSizeMismatch);
         }


### PR DESCRIPTION
Currently rebased against leongross/requester-version, once #23 is merged, we will rebase it against main/ `buildup.`

- add `GET_DIGESTS` request
- add `DIGESTS` response parsing
- refactor into common command structure `commands/{mod.rs, requester.rs, responder.rs}`

# Log 


```
$ cargo run --example spdm_requester --features="crypto" -- --port 2323 --verbose
...
GET_DIGESTS: Ok([13, 81, 0, 0])
DIGESTS: Ok([13, 1, 7, 7, dc, 2, 4e, 78, fa, 5e, 45, d8, 2e, 45, c6, 7f, b5, fc, e2, b9, 98, 7a, df, ee, 9e, a3, 3e, 56, d5, ed, 83, 47, e8, aa, a3, d0, 18, 91, 72, 7f, 3c, 5d, d7, a2, e1, ab, 7f, d3, 61, 38, 37, 5d, d, d, 5c, f1, c3, ba, 90, 2c, d5, 9c, 95, f2, 5e, 29, 15, f, a3, 78, 70, 8e, a1, cd, 97, 82, da, 82, ff, c3, ea, c4, 8e, 13, 48, 22, e, 89, ab, 97, f8, bb, 92, 8a, 82, 4e, 9e, f5, 95, 1f, dc, 2, 4e, 78, fa, 5e, 45, d8, 2e, 45, c6, 7f, b5, fc, e2, b9, 98, 7a, df, ee, 9e, a3, 3e, 56, d5, ed, 83, 47, e8, aa, a3, d0, 18, 91, 72, 7f, 3c, 5d, d7, a2, e1, ab, 7f, d3, 61, 38, 37, 5d])
```

```
...
SpdmReceiveRequest[0] msg SPDM_GET_DIGESTS(0x81), size (0x4): 
0000: 13 81 00 00 
SpdmSendResponse[0] ...
SpdmSendResponse[0]: msg SPDM_DIGESTS(0x1), size (0x94): 
0000: 13 01 07 07 dc 02 4e 78 fa 5e 45 d8 2e 45 c6 7f b5 fc e2 b9 98 7a df ee 9e a3 3e 56 d5 ed 83 47 
0020: e8 aa a3 d0 18 91 72 7f 3c 5d d7 a2 e1 ab 7f d3 61 38 37 5d 0d 0d 5c f1 c3 ba 90 2c d5 9c 95 f2 
0040: 5e 29 15 0f a3 78 70 8e a1 cd 97 82 da 82 ff c3 ea c4 8e 13 48 22 0e 89 ab 97 f8 bb 92 8a 82 4e 
0060: 9e f5 95 1f dc 02 4e 78 fa 5e 45 d8 2e 45 c6 7f b5 fc e2 b9 98 7a df ee 9e a3 3e 56 d5 ed 83 47 
0080: e8 aa a3 d0 18 91 72 7f 3c 5d d7 a2 e1 ab 7f d3 61 38 37 5d 
Platform port Transmit command: 00 00 00 01 
Platform port Transmit transport_type: 00 00 00 00 
Platform port Transmit size: 00 00 00 94 
Platform port Transmit buffer:
    13 01 07 07 dc 02 4e 78 fa 5e 45 d8 2e 45 c6 7f b5 fc e2 b9 98 7a df ee 9e a3 3e 56 d5 ed 83 47 e8 aa a3 d0 18 91 72 7f 3c 5d d7 a2 e1 ab 7f d3 61 38 37 5d 0d 0d 5c f1 c3 ba 90 2c d5 9c 95 f2 5e 29 15 0f a3 78 70 8e a1 cd 97 82 da 82 ff c3 ea c4 8e 13 48 22 0e 89 ab 97 f8 bb 92 8a 82 4e 9e f5 95 1f dc 02 4e 78 fa 5e 45 d8 2e 45 c6 7f b5 fc e2 b9 98 7a df ee 9e a3 3e 56 d5 ed 83 47 e8 aa a3 d0 18 91 72 7f 3c 5d d7 a2 e1 ab 7f d3 61 38 37 5d
```

### EDIT

To limit the slots to `slot[0]`, use
```
$ while 1; do ./spdm_responder_emu --trans NONE --ver 1.3 --slot_id 0 --slot_count 1 --req_slot_id 0; done
```