### PR TITLE
Add MCTP Transport Binding to Requester Example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,13 @@ hex = "0.4.3"
 der = "0.8"
 x509-cert = "0.3.0-rc.4"
 signature = "2"
+clap = { version = "4", features = ["derive"] }
 
 # Examples
 [[example]]
 name = "spdm_responder"
 path = "examples/spdm_responder.rs"
+
+[[example]]
+name = "spdm_requester"
+path = "examples/spdm_requester.rs"

--- a/examples/platform/socket_transport.rs
+++ b/examples/platform/socket_transport.rs
@@ -8,6 +8,7 @@
 use std::io::{Read, Result as IoResult, Write};
 use std::net::TcpStream;
 
+use clap::{Parser, ValueEnum};
 use spdm_lib::codec::{Codec, CodecError, CommonCodec, MessageBuf};
 use spdm_lib::platform::transport::{SpdmTransport, TransportError, TransportResult};
 use zerocopy::byteorder::{BigEndian, U32};
@@ -51,7 +52,7 @@ impl From<u32> for SocketSpdmCommand {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, ValueEnum)]
 #[repr(u32)]
 #[allow(non_camel_case_types, unused)]
 pub enum SocketTransportType {

--- a/examples/platform/socket_transport.rs
+++ b/examples/platform/socket_transport.rs
@@ -13,6 +13,8 @@ use spdm_lib::platform::transport::{SpdmTransport, TransportError, TransportResu
 use zerocopy::byteorder::{BigEndian, U32};
 use zerocopy::{FromBytes, Immutable, IntoBytes};
 
+use crate::platform;
+
 /// Socket platform command types (from DMTF emulator)
 /// This is **NOT** part of the official DMTF spec, but is necessary to implement
 /// [SocketTransportType::None].
@@ -297,17 +299,41 @@ impl SpdmSocketTransport {
     }
 
     /// Receive platform data with socket message header
+    ///
+    /// The transport specific headers such as MCTP header (see DSP0275) are encoded in the payload.
+    /// Note, that the payload size needs to be adjusted accordingly when sending/ receiving messages with transport specific headers.
     pub(crate) fn receive_platform_data(&mut self) -> IoResult<(SocketSpdmCommand, Vec<u8>)> {
         // Read socket message header
         let mut header_bytes = [0u8; 12]; // sizeof(SocketMessageHeader)
         self.stream.read_exact(&mut header_bytes)?;
-
         let header = SocketSpdmCommandHdr::from(&header_bytes);
         let payload_size = header.payload_size.get();
 
         if payload_size > 0 {
             let mut data = vec![0u8; payload_size as usize];
             self.stream.read_exact(&mut data)?;
+
+            // Parse and remove transport specific headers from the payload.
+            match self.transport_type {
+                SocketTransportType::None => {}
+                SocketTransportType::MCTP => {
+                    let mctp_header = data[0];
+                    if mctp_header != 0x5 {
+                        return Err(std::io::Error::new(
+                            std::io::ErrorKind::Other,
+                            "Invalid MCTP header",
+                        ));
+                    }
+                    data.remove(0);
+                }
+                _ => {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::Other,
+                        "Unsupported transport type",
+                    ));
+                }
+            }
+
             Ok((header.command, data))
         } else {
             Ok((header.command, Vec::new()))
@@ -315,18 +341,35 @@ impl SpdmSocketTransport {
     }
 
     /// Send platform data with socket message header
+    ///
+    /// Depending on the [SocketTransportType], this may prepend additional transport-specific headers to the data.
     fn send_platform_data(&mut self, command: SocketSpdmCommand, data: &[u8]) -> IoResult<()> {
+        let mut platform_header: &[u8] = &[];
+        match self.transport_type {
+            SocketTransportType::None => {}
+
+            SocketTransportType::MCTP => {
+                platform_header = &[0x5];
+            }
+            _ => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    "Unsupported transport type",
+                ));
+            }
+        }
+
         let header_bytes: [u8; 12] = SocketSpdmCommandHdr {
             command: SocketSpdmCommand::from(command as u32),
             transport_type: self.transport_type,
-            payload_size: BeU32::new(data.len() as u32),
+            payload_size: BeU32::new((data.len() + platform_header.len()) as u32),
         }
         .into();
 
         self.stream.write_all(&header_bytes)?;
 
-        // Send data if any
         if !data.is_empty() {
+            self.stream.write_all(platform_header)?;
             self.stream.write_all(data)?;
         }
 
@@ -347,9 +390,7 @@ impl SpdmTransport for SpdmSocketTransport {
     /// This function is only relevant for the SPDM Requester.
     /// Send the SPDM Request encoded into [req] (header|payload]) via the platform transport
     /// to and SPDM endpoint.
-    /// Since this binding implements DSP0276, "Secured Messages using SPDM over MCTP Binding Specification",
-    /// there is no EID to send it to.
-    fn send_request<'a>(&mut self, _dest_eid: u8, req: &mut MessageBuf<'a>) -> TransportResult<()> {
+    fn send_request<'a>(&mut self, dest_eid: u8, req: &mut MessageBuf<'a>) -> TransportResult<()> {
         let message_data = req
             .message_data()
             .map_err(|_| TransportError::BufferTooSmall)?;

--- a/examples/platform/socket_transport.rs
+++ b/examples/platform/socket_transport.rs
@@ -75,6 +75,22 @@ impl From<u32> for SocketTransportType {
     }
 }
 
+/// # MCTP
+///  Header = `IC | MessageType`, where
+/// - `IC` is the integrity check byte, which is set to 0 for SPDM messages.
+/// - `MessageType` is set to 0x5 for SPDM messages.
+impl SocketTransportType {
+    pub fn transport_header(&self) -> TransportResult<&[u8]> {
+        match self {
+            SocketTransportType::None => Ok(&[]),
+            SocketTransportType::MCTP => Ok(&[0x5]),
+            SocketTransportType::PCI_DOE | SocketTransportType::TCP => {
+                Err(TransportError::UnsupportedTransportType)
+            }
+        }
+    }
+}
+
 pub enum SocketMessageHeaderError {
     Reserved,
 }
@@ -144,6 +160,8 @@ pub enum SpdmSocketTransportError {
     CannotBeResponder = 0xC3,
     //0xC4 - 0xFF: Reserved.
 }
+
+type SpdmSocketTransportResult<T> = Result<T, SpdmSocketTransportError>;
 
 impl TryFrom<u8> for SpdmSocketTransportError {
     type Error = SocketMessageHeaderError;
@@ -318,8 +336,12 @@ impl SpdmSocketTransport {
             match self.transport_type {
                 SocketTransportType::None => {}
                 SocketTransportType::MCTP => {
-                    let mctp_header = data[0];
-                    if mctp_header != 0x5 {
+                    let mctp_header_got = data[0];
+                    let mctp_header_want = self.transport_type.transport_header().map_err(|e| {
+                        std::io::Error::new(std::io::ErrorKind::Other, format!("{:?}", e))
+                    })?[0];
+
+                    if mctp_header_got != mctp_header_want {
                         return Err(std::io::Error::new(
                             std::io::ErrorKind::Other,
                             "Invalid MCTP header",
@@ -378,7 +400,7 @@ impl SpdmSocketTransport {
         Ok(())
     }
 
-    pub fn send_client_hello<'a>(&mut self) -> TransportResult<()> {
+    pub fn send_client_hello(&mut self) -> TransportResult<()> {
         let message_data = b"Client Hello!\x00".as_bytes();
 
         self.send_platform_data(SocketSpdmCommand::Test, message_data)
@@ -391,7 +413,7 @@ impl SpdmTransport for SpdmSocketTransport {
     /// This function is only relevant for the SPDM Requester.
     /// Send the SPDM Request encoded into [req] (header|payload]) via the platform transport
     /// to and SPDM endpoint.
-    fn send_request<'a>(&mut self, dest_eid: u8, req: &mut MessageBuf<'a>) -> TransportResult<()> {
+    fn send_request<'a>(&mut self, _dest_eid: u8, req: &mut MessageBuf<'a>) -> TransportResult<()> {
         let message_data = req
             .message_data()
             .map_err(|_| TransportError::BufferTooSmall)?;

--- a/examples/spdm_requester.rs
+++ b/examples/spdm_requester.rs
@@ -2,11 +2,10 @@
 
 //! SPDM Example Responder utilizing the requester library.
 
-use std::env;
 use std::io::{Error, ErrorKind, Result as IoResult};
 use std::net::TcpStream;
-use std::process;
 
+use clap::Parser;
 use der::{Decode, Encode};
 use p384::ecdsa::{Signature, VerifyingKey};
 use spdm_lib::codec::MessageBuf;
@@ -44,26 +43,34 @@ use x509_cert::Certificate;
 /// ECP384 CA cert from spdm-emu
 const CA_CERT: &[u8] = include_bytes!("cert/ecp384_ca.cert.der");
 
-/// Responder configuration
-#[derive(Debug, Clone)]
+/// SPDM Example Requester
+#[derive(Debug, Clone, Parser)]
+#[command(about = "Real SPDM Library Integrated DMTF Compatible Requester")]
 struct RequesterConfig {
+    /// TCP TCP port to connect to.
+    /// This needs to be supplied for both type NONE and MCTP.
+    #[arg(short, long, default_value_t = 2323)]
     port: u16,
-    cert_path: String,
-    key_path: String,
-    measurements_path: Option<String>,
-    verbose: bool,
-}
 
-impl Default for RequesterConfig {
-    fn default() -> Self {
-        Self {
-            port: 2323,
-            cert_path: "device_cert.pem".to_string(),
-            key_path: "device_key.pem".to_string(),
-            measurements_path: Some("measurements.json".to_string()),
-            verbose: false,
-        }
-    }
+    /// Path to certificate file
+    #[arg(short, long, default_value = "device_cert.pem")]
+    cert_path: String,
+
+    /// Path to private key file
+    #[arg(short = 'k', long, default_value = "device_key.pem")]
+    key_path: String,
+
+    /// Path to measurements file
+    #[arg(short, long)]
+    measurements_path: Option<String>,
+
+    /// Enable verbose logging
+    #[arg(short, long)]
+    verbose: bool,
+
+    /// Transport type to use for the connection
+    #[arg(short, long, default_value_t = platform::socket_transport::SocketTransportType::None, value_enum)]
+    transport_type: platform::socket_transport::SocketTransportType,
 }
 
 /// Create SPDM device capabilities
@@ -133,10 +140,7 @@ fn create_local_algorithms<'a>() -> LocalDeviceAlgorithms<'a> {
 // Perform a VCS flow (Version, Capabilities, Algorithms)
 // using the real SPDM library processing with platform implementations.
 fn full_flow(stream: TcpStream, config: &RequesterConfig) -> IoResult<()> {
-    let mut transport = SpdmSocketTransport::new(
-        stream,
-        platform::socket_transport::SocketTransportType::None,
-    );
+    let mut transport = SpdmSocketTransport::new(stream, config.transport_type);
     const EID: u8 = 0;
 
     // Create platform implementations - all from platform module!
@@ -159,7 +163,10 @@ fn full_flow(stream: TcpStream, config: &RequesterConfig) -> IoResult<()> {
     let mut peer_cert_store = ExamplePeerCertStore::default();
 
     if config.verbose {
-        println!("Client connected - initializing SPDM context");
+        println!(
+            "Client connected with transport type: {:?}",
+            config.transport_type
+        );
     }
 
     // TODO: The SpdmContext has to be adjusted (best in a generic way) to be requester compatible
@@ -194,12 +201,16 @@ fn full_flow(stream: TcpStream, config: &RequesterConfig) -> IoResult<()> {
     // Before we can start, we need to do the inofficial handshake for SOCKET_TRANSPORT_TYPE_NONE
     // 1. Send SOCKET_SPDM_COMMAND_TEST with payload b'Client Hello!'
     // 2. Receive SOCKET_SPDM_COMMAND_TEST with payload b'Server Hello!'
-    spdm_context.transport_init_sequence().map_err(|e| {
-        eprintln!("Handshake failed: {:?}", e);
-        Error::new(ErrorKind::Other, "SPDM handshake failed")
-    })?;
+    if config.transport_type == platform::socket_transport::SocketTransportType::None {
+        spdm_context.transport_init_sequence().map_err(|e| {
+            eprintln!("Handshake failed: {:?}", e);
+            Error::new(ErrorKind::Other, "SPDM handshake failed")
+        })?;
+    }
 
-    if config.verbose {
+    if config.verbose
+        && config.transport_type == platform::socket_transport::SocketTransportType::None
+    {
         println!("Initial handshake completed successfully");
     }
 
@@ -475,97 +486,6 @@ fn full_flow(stream: TcpStream, config: &RequesterConfig) -> IoResult<()> {
     Ok(())
 }
 
-/// Parse command line arguments
-fn parse_args() -> RequesterConfig {
-    let mut config = RequesterConfig::default();
-    let args: Vec<String> = env::args().collect();
-
-    let mut i = 1;
-    while i < args.len() {
-        match args[i].as_str() {
-            "-p" | "--port" => {
-                if i + 1 < args.len() {
-                    config.port = args[i + 1].parse().unwrap_or_else(|_| {
-                        eprintln!("Invalid port number: {}", args[i + 1]);
-                        process::exit(1);
-                    });
-                    i += 2;
-                } else {
-                    eprintln!("Port number required after {}", args[i]);
-                    process::exit(1);
-                }
-            }
-            "-c" | "--cert" => {
-                if i + 1 < args.len() {
-                    config.cert_path = args[i + 1].clone();
-                    i += 2;
-                } else {
-                    eprintln!("Certificate file path required after {}", args[i]);
-                    process::exit(1);
-                }
-            }
-            "-k" | "--key" => {
-                if i + 1 < args.len() {
-                    config.key_path = args[i + 1].clone();
-                    i += 2;
-                } else {
-                    eprintln!("Private key file path required after {}", args[i]);
-                    process::exit(1);
-                }
-            }
-            "-m" | "--measurements" => {
-                if i + 1 < args.len() {
-                    config.measurements_path = Some(args[i + 1].clone());
-                    i += 2;
-                } else {
-                    eprintln!("Measurements file path required after {}", args[i]);
-                    process::exit(1);
-                }
-            }
-            "-v" | "--verbose" => {
-                config.verbose = true;
-                i += 1;
-            }
-            "-h" | "--help" => {
-                print_help();
-                process::exit(0);
-            }
-            _ => {
-                eprintln!("Unknown argument: {}", args[i]);
-                print_help();
-                process::exit(1);
-            }
-        }
-    }
-
-    config
-}
-
-fn print_help() {
-    println!("Real SPDM Library Integrated DMTF Compatible Responder\n");
-    println!("USAGE:");
-    println!("    spdm-responder-clean [OPTIONS]\n");
-    println!("OPTIONS:");
-    println!("    -p, --port <PORT>              TCP port to connect to [default: None]");
-    println!(
-        "    -c, --cert <CERT_FILE>         Path to certificate file [default: device_cert.pem]"
-    );
-    println!(
-        "    -k, --key <KEY_FILE>           Path to private key file [default: device_key.pem]"
-    );
-    println!(
-        "    -m, --measurements <FILE>      Path to measurements file [default: measurements.json]"
-    );
-    println!("    -v, --verbose                  Enable verbose logging");
-    println!("    -h, --help                     Print this help message\n");
-    println!("EXAMPLES:");
-    println!("    spdm-responder-clean --port 8080 --verbose");
-    println!("    spdm-responder-clean --cert my_cert.pem --key my_key.pem");
-    println!(
-        "\nIntegrates real SPDM library with clean platform implementations - no code duplication!"
-    );
-}
-
 /// Display configuration information
 fn display_info(config: &RequesterConfig) {
     println!("Real SPDM Library Integrated DMTF Compatible Responder");
@@ -620,7 +540,7 @@ fn display_info(config: &RequesterConfig) {
 
 /// Main function
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let config = parse_args();
+    let config = RequesterConfig::parse();
     display_info(&config);
 
     let remote_addr = format!("0.0.0.0:{}", config.port);

--- a/src/platform/transport.rs
+++ b/src/platform/transport.rs
@@ -28,6 +28,7 @@ pub enum TransportError {
     SendError,
     ResponseNotExpected,
     NoRequestInFlight,
+    UnsupportedTransportType,
 
     /// Error specific to SOCKET_TRANSPORT_TYPE_NONE handshake
     HandshakeNoneError,


### PR DESCRIPTION
Add MCTP Transport Binding to Requester Example. For the DMTF spec, see [DSP0275](https://www.dmtf.org/sites/default/files/standards/documents/DSP0275_1.0.1.pdf).

- Add MCTP header parsing 
- Migrate hand-written CLI to clap
- Add `--transport-type` / `-t` flag
- Add default values for config