### PR TITLE
Add missing license headers to comply with Apache-2.0

### DIFF
--- a/examples/platform/cert_store.rs
+++ b/examples/platform/cert_store.rs
@@ -1,4 +1,16 @@
-// Licensed under the Apache-2.0 license
+// Copyright 2025
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 //! Certificate Store Platform Implementation
 //!

--- a/examples/platform/certs.rs
+++ b/examples/platform/certs.rs
@@ -1,4 +1,16 @@
-// Licensed under the Apache-2.0 license
+// Copyright 2025
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 //! Static X.509 certificates for SPDM platform implementations
 //!

--- a/examples/platform/crypto.rs
+++ b/examples/platform/crypto.rs
@@ -1,4 +1,16 @@
-// Licensed under the Apache-2.0 license
+// Copyright 2025
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 //! Cryptographic Platform Implementation
 //!

--- a/examples/platform/evidence.rs
+++ b/examples/platform/evidence.rs
@@ -1,4 +1,16 @@
-// Licensed under the Apache-2.0 license
+// Copyright 2025
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 //! Evidence Platform Implementation
 //!

--- a/examples/platform/mod.rs
+++ b/examples/platform/mod.rs
@@ -1,4 +1,16 @@
-// Licensed under the Apache-2.0 license
+// Copyright 2025
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 //! Platform implementations for SPDM examples
 //!

--- a/examples/platform/socket_transport.rs
+++ b/examples/platform/socket_transport.rs
@@ -1,4 +1,16 @@
-// Licensed under the Apache-2.0 license
+// Copyright 2025
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 //! Socket Transport Platform Implementation
 //!

--- a/examples/spdm_requester.rs
+++ b/examples/spdm_requester.rs
@@ -1,4 +1,16 @@
-// Licensed under the Apache-2.0 license
+// Copyright 2025
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 //! SPDM Example Responder utilizing the requester library.
 

--- a/examples/spdm_responder.rs
+++ b/examples/spdm_responder.rs
@@ -1,4 +1,16 @@
-// Licensed under the Apache-2.0 license
+// Copyright 2025
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 //! Real SPDM Library Integrated DMTF Compatible Responder
 //!

--- a/src/cert_store.rs
+++ b/src/cert_store.rs
@@ -1,4 +1,16 @@
-// Licensed under the Apache-2.0 license
+// Copyright 2025
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 use crate::error::{SpdmError, SpdmResult};
 use crate::protocol::algorithms::{AsymAlgo, ECC_P384_SIGNATURE_SIZE, SHA384_HASH_SIZE};

--- a/src/chunk_ctx.rs
+++ b/src/chunk_ctx.rs
@@ -1,4 +1,16 @@
-// Licensed under the Apache-2.0 license
+// Copyright 2025
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 use crate::commands::measurements_rsp::MeasurementsResponse;
 

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -1,4 +1,16 @@
-// Licensed under the Apache-2.0 license
+// Copyright 2025
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 use zerocopy::{FromBytes, Immutable, IntoBytes};
 

--- a/src/commands/algorithms/mod.rs
+++ b/src/commands/algorithms/mod.rs
@@ -1,4 +1,16 @@
-// Licensed under the Apache-2.0 license
+// Copyright 2025
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 //! Commands related to SPDM Algorithms negotiation
 //! See DMTF 0274 - SPDM Base Specification v1.3, Section 10.4 ff.

--- a/src/commands/algorithms/request.rs
+++ b/src/commands/algorithms/request.rs
@@ -1,4 +1,16 @@
-// Licensed under the Apache-2.0 license
+// Copyright 2025
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 use crate::{
     codec::{Codec, MessageBuf},

--- a/src/commands/algorithms/response.rs
+++ b/src/commands/algorithms/response.rs
@@ -1,4 +1,16 @@
-// Licensed under the Apache-2.0 license
+// Copyright 2025
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 use crate::{
     codec::{Codec, MessageBuf},

--- a/src/commands/capabilities/mod.rs
+++ b/src/commands/capabilities/mod.rs
@@ -1,4 +1,16 @@
-// Licensed under the Apache-2.0 license
+// Copyright 2025
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 pub mod request;
 pub mod response;

--- a/src/commands/capabilities/request.rs
+++ b/src/commands/capabilities/request.rs
@@ -1,4 +1,16 @@
-// Licensed under the Apache-2.0 license
+// Copyright 2025
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 use crate::commands::error_rsp::ErrorCode;
 use crate::protocol::CapabilityFlags;

--- a/src/commands/capabilities/response.rs
+++ b/src/commands/capabilities/response.rs
@@ -1,4 +1,16 @@
-// Licensed under the Apache-2.0 license
+// Copyright 2025
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 use super::*;
 use crate::codec::{Codec, MessageBuf};
 use crate::commands::error_rsp::ErrorCode;

--- a/src/commands/certificate/mod.rs
+++ b/src/commands/certificate/mod.rs
@@ -1,4 +1,16 @@
-// Licensed under the Apache-2.0 license
+// Copyright 2025
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 pub mod request;
 pub mod response;

--- a/src/commands/certificate/request.rs
+++ b/src/commands/certificate/request.rs
@@ -1,4 +1,16 @@
-// Licensed under the Apache-2.0 license
+// Copyright 2025
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 use crate::codec::{Codec, MessageBuf};
 use crate::commands::certificate::{

--- a/src/commands/certificate/response.rs
+++ b/src/commands/certificate/response.rs
@@ -1,4 +1,16 @@
-// Licensed under the Apache-2.0 license
+// Copyright 2025
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 use crate::cert_store::{cert_slot_mask, MAX_CERT_SLOTS_SUPPORTED};
 use crate::codec::{Codec, MessageBuf};

--- a/src/commands/challenge/mod.rs
+++ b/src/commands/challenge/mod.rs
@@ -1,4 +1,16 @@
-// Licensed under the Apache-2.0 license
+// Copyright 2025
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 use crate::codec::CommonCodec;
 use crate::protocol::SHA384_HASH_SIZE;

--- a/src/commands/challenge/request.rs
+++ b/src/commands/challenge/request.rs
@@ -1,4 +1,16 @@
-// Licensed under the Apache-2.0 license
+// Copyright 2025
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 use crate::codec::{encode_u8_slice, Codec, MessageBuf};
 use crate::commands::challenge::{
     ChallengeAuthRspBase, ChallengeReq, MeasurementSummaryHashType, CONTEXT_LEN, NONCE_LEN,

--- a/src/commands/challenge/response.rs
+++ b/src/commands/challenge/response.rs
@@ -1,4 +1,16 @@
-// Licensed under the Apache-2.0 license
+// Copyright 2025
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 use crate::cert_store::MAX_CERT_SLOTS_SUPPORTED;
 use crate::codec::{Codec, MessageBuf};
 use crate::commands::algorithms::selected_measurement_specification;

--- a/src/commands/chunk_get_rsp.rs
+++ b/src/commands/chunk_get_rsp.rs
@@ -1,4 +1,16 @@
-// Licensed under the Apache-2.0 license
+// Copyright 2025
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 use crate::chunk_ctx::ChunkError;
 use crate::chunk_ctx::LargeResponse;
 use crate::codec::{Codec, CommonCodec, MessageBuf};

--- a/src/commands/digests/mod.rs
+++ b/src/commands/digests/mod.rs
@@ -1,4 +1,16 @@
-// Licensed under the Apache-2.0 license
+// Copyright 2025
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 use crate::cert_store::SpdmCertStore;
 use crate::codec::{CommonCodec, MessageBuf};

--- a/src/commands/digests/request.rs
+++ b/src/commands/digests/request.rs
@@ -1,4 +1,16 @@
-// Licensed under the Apache-2.0 license
+// Copyright 2025
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 use crate::codec::Codec;
 use crate::context::SpdmContext;

--- a/src/commands/digests/response.rs
+++ b/src/commands/digests/response.rs
@@ -1,4 +1,16 @@
-// Licensed under the Apache-2.0 license
+// Copyright 2025
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 use crate::cert_store::cert_slot_mask;
 use crate::codec::{Codec, MessageBuf};

--- a/src/commands/error_rsp.rs
+++ b/src/commands/error_rsp.rs
@@ -1,4 +1,16 @@
-// Licensed under the Apache-2.0 license
+// Copyright 2025
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 use crate::codec::{Codec, CommonCodec, MessageBuf};
 use crate::error::CommandError;

--- a/src/commands/measurements_rsp.rs
+++ b/src/commands/measurements_rsp.rs
@@ -1,4 +1,16 @@
-// Licensed under the Apache-2.0 license
+// Copyright 2025
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 use crate::cert_store::SpdmCertStore;
 use crate::chunk_ctx::{ChunkError, LargeResponse};

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,4 +1,16 @@
-// Licensed under the Apache-2.0 license
+// Copyright 2025
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 pub mod algorithms;
 pub mod capabilities;

--- a/src/commands/version/mod.rs
+++ b/src/commands/version/mod.rs
@@ -1,4 +1,16 @@
-// Licensed under the Apache-2.0 license
+// Copyright 2025
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 pub mod request;
 pub mod response;
 

--- a/src/commands/version/request.rs
+++ b/src/commands/version/request.rs
@@ -1,4 +1,16 @@
-// Licensed under the Apache-2.0 license
+// Copyright 2025
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 use crate::{
     codec::{Codec, MessageBuf},

--- a/src/commands/version/response.rs
+++ b/src/commands/version/response.rs
@@ -1,4 +1,16 @@
-// Licensed under the Apache-2.0 license
+// Copyright 2025
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 use crate::codec::{Codec, MessageBuf};
 use crate::commands::error_rsp::ErrorCode;

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,4 +1,16 @@
-// Licensed under the Apache-2.0 license
+// Copyright 2025
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 // use crate::cert_mgr::DeviceCertsManager;
 use crate::cert_store::*;

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,16 @@
-// Licensed under the Apache-2.0 license
+// Copyright 2025
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 // use crate::cert_mgr::DeviceCertsMgrError;
 use crate::cert_store::CertStoreError;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,16 @@
-// Licensed under the Apache-2.0 license
+// Copyright 2025
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #![cfg_attr(not(test), no_std)]
 

--- a/src/measurements/common.rs
+++ b/src/measurements/common.rs
@@ -1,8 +1,20 @@
-// Licensed under the Apache-2.0 license
+// Copyright 2025
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+use crate::commands::challenge::MeasurementSummaryHashType;
 use crate::measurements::freeform_manifest::FreeformManifest;
 use crate::platform::evidence::{SpdmEvidence, SpdmEvidenceError};
 use crate::platform::hash::{SpdmHash, SpdmHashError};
-use crate::commands::challenge::MeasurementSummaryHashType;
 use crate::protocol::{algorithms::AsymAlgo, MeasurementSpecification, SHA384_HASH_SIZE};
 use bitfield::bitfield;
 use zerocopy::{FromBytes, Immutable, IntoBytes};

--- a/src/measurements/freeform_manifest.rs
+++ b/src/measurements/freeform_manifest.rs
@@ -1,4 +1,16 @@
-// Licensed under the Apache-2.0 license
+// Copyright 2025
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 use crate::commands::challenge::MeasurementSummaryHashType;
 use crate::measurements::common::{

--- a/src/measurements/mod.rs
+++ b/src/measurements/mod.rs
@@ -1,4 +1,16 @@
-// Licensed under the Apache-2.0 license
+// Copyright 2025
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 pub mod common;
 pub mod freeform_manifest;

--- a/src/platform/evidence.rs
+++ b/src/platform/evidence.rs
@@ -1,3 +1,17 @@
+// Copyright 2025
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 pub const PCR_QUOTE_BUFFER_SIZE: usize = 0x1984;
 
 pub type SpdmEvidenceResult<T> = Result<T, SpdmEvidenceError>;

--- a/src/platform/hash.rs
+++ b/src/platform/hash.rs
@@ -1,3 +1,17 @@
+// Copyright 2025
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 pub type SpdmHashResult<T> = Result<T, SpdmHashError>;
 
 pub trait SpdmHash {

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -1,3 +1,17 @@
+// Copyright 2025
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 pub mod evidence;
 pub mod hash;
 pub mod rng;

--- a/src/platform/rng.rs
+++ b/src/platform/rng.rs
@@ -1,3 +1,17 @@
+// Copyright 2025
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 pub type SpdmRngResult<T> = Result<T, SpdmRngError>;
 
 #[derive(Debug, PartialEq)]

--- a/src/platform/transport.rs
+++ b/src/platform/transport.rs
@@ -1,3 +1,17 @@
+// Copyright 2025
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use crate::codec::{CodecError, MessageBuf};
 
 pub type TransportResult<T> = Result<T, TransportError>;

--- a/src/protocol/algorithms.rs
+++ b/src/protocol/algorithms.rs
@@ -1,4 +1,16 @@
-// Licensed under the Apache-2.0 license
+// Copyright 2025
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 use crate::error::{SpdmError, SpdmResult};
 use bitfield::bitfield;

--- a/src/protocol/capabilities.rs
+++ b/src/protocol/capabilities.rs
@@ -1,4 +1,16 @@
-// Licensed under the Apache-2.0 license
+// Copyright 2025
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 use bitfield::bitfield;
 use zerocopy::{FromBytes, Immutable, IntoBytes};

--- a/src/protocol/certs.rs
+++ b/src/protocol/certs.rs
@@ -1,4 +1,16 @@
-// Licensed under the Apache-2.0 license
+// Copyright 2025
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 use crate::protocol::{SpdmVersion, SHA384_HASH_SIZE};
 use bitfield::bitfield;
 use zerocopy::{little_endian, FromBytes, Immutable, IntoBytes, KnownLayout};

--- a/src/protocol/common.rs
+++ b/src/protocol/common.rs
@@ -1,4 +1,16 @@
-// Licensed under the Apache-2.0 license
+// Copyright 2025
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 use crate::codec::CommonCodec;
 use crate::error::{SpdmError, SpdmResult};

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -1,4 +1,16 @@
-// Licensed under the Apache-2.0 license
+// Copyright 2025
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 pub mod algorithms;
 pub mod capabilities;

--- a/src/protocol/signature.rs
+++ b/src/protocol/signature.rs
@@ -1,4 +1,16 @@
-// Licensed under the Apache-2.0 license
+// Copyright 2025
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 use crate::platform::hash::{SpdmHash, SpdmHashError};
 use crate::protocol::*;

--- a/src/protocol/version.rs
+++ b/src/protocol/version.rs
@@ -1,4 +1,16 @@
-// Licensed under the Apache-2.0 license
+// Copyright 2025
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 use crate::error::{SpdmError, SpdmResult};
 

--- a/src/requester.rs
+++ b/src/requester.rs
@@ -1,5 +1,0 @@
-// Licensed under the Apache-2.0 license
-
-struct Requester<'a> {
-    context: 
-}

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,4 +1,16 @@
-// Licensed under the Apache-2.0 license
+// Copyright 2025
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 use crate::{
     cert_store::PeerCertStore,

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,3 +1,17 @@
+// Copyright 2025
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use crate::{
     cert_store::{CertStoreResult, SpdmCertStore},
     context::SpdmContext,

--- a/src/transcript.rs
+++ b/src/transcript.rs
@@ -1,4 +1,16 @@
-// Licensed under the Apache-2.0 license
+// Copyright 2025
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 use crate::platform::hash::{SpdmHash, SpdmHashError};
 use crate::protocol::{SpdmVersion, SHA384_HASH_SIZE};

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -1,4 +1,16 @@
-// Licensed under the Apache-2.0 license
+// Copyright 2025
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 use crate::codec::MessageBuf;
 use crate::codec::{Codec, CodecError, CommonCodec, DataKind};

--- a/tests/spdm_validator_host.rs
+++ b/tests/spdm_validator_host.rs
@@ -1,3 +1,17 @@
+// Copyright 2025
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //! Basic instantiation test for SpdmContext (host validator)
 //! Run with: cargo test --features std -- --nocapture
 


### PR DESCRIPTION
Update all source files to include the complete Apache 2 license header.