### PR TITLE
fix: responder algorithms

### DIFF
--- a/examples/spdm_requester.rs
+++ b/examples/spdm_requester.rs
@@ -323,7 +323,7 @@ fn full_flow(stream: TcpStream, config: &RequesterConfig) -> IoResult<()> {
         &mut message_buffer,
         Some(&ext_asym),
         Some(&ext_hash),
-        alg_structure,
+        Some(alg_structure),
         Some(&alg_external),
     )
     .unwrap();

--- a/src/commands/algorithms/mod.rs
+++ b/src/commands/algorithms/mod.rs
@@ -188,8 +188,7 @@ impl NegotiateAlgorithmsReq {
             + size_of::<NegotiateAlgorithmsReq>()
             + total_alg_struct_len
             + total_ext_asym_len
-            + total_ext_hash_len
-            + 4) as u16
+            + total_ext_hash_len) as u16
     }
 
     /// Calculate the size of the extended algorithm structures in bytes.

--- a/src/commands/algorithms/mod.rs
+++ b/src/commands/algorithms/mod.rs
@@ -150,9 +150,10 @@ impl NegotiateAlgorithmsReq {
         other_param_support: OtherParamSupport,
         base_asym_algo: BaseAsymAlgo,
         base_hash_algo: BaseHashAlgo,
-        ext_asyn_count: u8,
+        ext_asym_count: u8,
         ext_hash_count: u8,
         mel_specification: MelSpecification,
+        alg_ext_count: u8,
     ) -> SpdmResult<NegotiateAlgorithmsReq> {
         let mut req = NegotiateAlgorithmsReq {
             num_alg_struct_tables,
@@ -163,13 +164,14 @@ impl NegotiateAlgorithmsReq {
             base_asym_algo,
             base_hash_algo,
             reserved_1: [0u8; 12],
-            ext_asym_count: ext_asyn_count,
+            ext_asym_count,
             ext_hash_count,
             reserved_2: 0,
             mel_specification,
         };
 
-        req.length = req.min_req_len();
+        req.length = req.min_req_len()
+            + (size_of::<ExtendedAlgo>() * alg_ext_count as usize) as u16;
 
         if req.length > MAX_SPDM_REQUEST_LENGTH {
             return Err(SpdmError::InvalidParam);

--- a/src/commands/algorithms/request.rs
+++ b/src/commands/algorithms/request.rs
@@ -169,7 +169,7 @@ pub fn generate_negotiate_algorithms_request<'a>(
     req_buf: &mut MessageBuf<'a>,
     ext_asym: Option<&'a [ExtendedAlgo]>,
     ext_hash: Option<&'a [ExtendedAlgo]>,
-    req_alg_struct: AlgStructure,
+    req_alg_struct: Option<AlgStructure>,
     alg_external: Option<&'a [ExtendedAlgo]>, // req_alg_struct.AlgCount.ExtAlgCount many
 ) -> CommandResult<()> {
     let local_algorithms = &ctx.local_algorithms.device_algorithms;
@@ -184,9 +184,12 @@ pub fn generate_negotiate_algorithms_request<'a>(
         None => 0,
     };
 
+    let num_alg_struct_tables = req_alg_struct.is_some() as u8;
+    let alg_ext_count = req_alg_struct.map_or(0, |s| s.ext_alg_count());
+
     // Generate base structure **without** the variable length structures
     let negotiate_algorithms_req = NegotiateAlgorithmsReq::new(
-        req_alg_struct.ext_alg_count(),
+        num_alg_struct_tables,
         0, // param2
         local_algorithms.measurement_spec,
         local_algorithms.other_param_support,
@@ -195,6 +198,7 @@ pub fn generate_negotiate_algorithms_request<'a>(
         ext_asym_count,
         ext_hash_count,
         local_algorithms.mel_specification,
+        alg_ext_count,
     )
     .map_err(|_| (false, CommandError::UnsupportedRequest))?;
 
@@ -253,27 +257,23 @@ pub fn generate_negotiate_algorithms_request<'a>(
         }
     }
 
-    // 3.2
-    if req_alg_struct.fixed_alg_count() != 0 && !req_alg_struct.is_multiple() {
-        return Err((false, CommandError::UnsupportedRequest));
-    }
+    // 3.3 + 3.4: encode AlgStructure and its extended algorithms if present
+    if let Some(alg_struct) = req_alg_struct {
+        if alg_struct.fixed_alg_count() != 0 && !alg_struct.is_multiple() {
+            return Err((false, CommandError::UnsupportedRequest));
+        }
 
-    // If this is 1, we have an additional extended algorithm structure to add.
-    if negotiate_algorithms_req.num_alg_struct_tables > 0 {
-        // 3.3
-        req_alg_struct
+        alg_struct
             .encode(req_buf)
             .map_err(|e| (false, CommandError::Codec(e)))?;
 
-        // 3.4
-        if let Some(extended_algos) = alg_external {
+        // If ext_alg_count > 0, we must have the extended algorithm structures.
+        if alg_struct.ext_alg_count() > 0 {
+            let extended_algos = alg_external.ok_or((false, CommandError::UnsupportedRequest))?;
             for ext in extended_algos {
                 ext.encode(req_buf)
                     .map_err(|e| (false, CommandError::Codec(e)))?;
             }
-        } else {
-            // If ext_alg_count > 0, we must have the extended algorithm structure.
-            return Err((false, CommandError::UnsupportedRequest));
         }
     }
 

--- a/src/commands/algorithms/response.rs
+++ b/src/commands/algorithms/response.rs
@@ -134,6 +134,13 @@ fn process_negotiate_algorithms_request<'a>(
         if fixed_alg_count != 2 {
             Err(ctx.generate_error_response(req_payload, ErrorCode::InvalidRequest, 0, None))?;
         }
+
+        // Skip extended algorithm structures embedded in this AlgStructure
+        for _ in 0..ext_alg_count {
+            ExtendedAlgo::decode(req_payload).map_err(|_| {
+                ctx.generate_error_response(req_payload, ErrorCode::InvalidRequest, 0, None)
+            })?;
+        }
     }
 
     // Total number of extended algorithms check


### PR DESCRIPTION
Resolves #41 

The Action still fails because of #44
```
thread 'main' (3212) panicked at examples/spdm_requester.rs:431:13:
assertion `left == right` failed
  left: [48, 101, 2, 49, 0, 146, 81, 128, 123, 16, 239, 183, 3, 90, 219, 148, 202, 47, 16, 50, 172, 165, 186, 204, 155, 36, 224, 252, 237, 149, 251, 109, 46, 142, 239, 251, 82, 223, 240, 41, 111, 207, 70, 73, 175, 223, 83, 47, 199, 197, 93, 113, 177, 2, 48, 104, 118, 111, 126, 2, 247, 111, 191, 80, 253, 80, 174, 192, 72, 169, 214, 151, 158, 50, 105, 45, 0, 148, 164, 83, 111, 156, 36, 35, 108, 166, 152, 22, 128, 225, 230, 201, 57, 26, 83, 214, 177, 84, 116, 173, 141, 137, 222]
 right: [48, 101, 2, 48, 42, 50, 149, 44, 255, 170, 31, 51, 82, 111, 108, 253, 64, 114, 255, 23, 137, 110, 3, 95, 187, 66, 3, 196, 110, 23, 134, 170, 152, 168, 193, 32, 18, 217, 4, 124, 22, 234, 31, 174, 138, 239, 133, 17, 65, 87, 223, 252, 2, 49, 0, 168, 76, 185, 144, 75, 47, 106, 79, 194, 142, 216, 35, 173, 129, 222, 76, 81, 80, 11, 39, 23, 143, 70, 38, 137, 59, 159, 249, 206, 72, 224, 238, 40, 253, 63, 6, 225, 179, 77, 143, 108, 72, 28, 42, 148, 169, 208, 222]
``` 

See https://github.com/9elements/spdm-lib/pull/45 for the round-trip fix.